### PR TITLE
Escape html to prevent XSS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem "engtagger"
 gem "faraday"
 gem "faraday_middleware"
 
+# 自動HTMLエスケープ
+gem "erubis"
+
 # JSON
 gem "json"
 

--- a/main.rb
+++ b/main.rb
@@ -7,6 +7,11 @@ if settings.development?
   require 'sinatra/reloader'
 end
 
+# ERBテンプレートで変数を自動エスケープ
+# cf. http://www.sinatrarb.com/faq.html#auto_escape_html
+require 'erubis'
+set :erb, :escape_html => true
+
 # クラス
 require './class/vine.rb'
 require './class/itunes.rb'

--- a/views/result.erb
+++ b/views/result.erb
@@ -20,9 +20,11 @@
         <div id="bpm"><%= @bpm %></div>
         <audio id="audio" src="<%= @music_url %>"></audio>
         <% @videos.each do |video| %>
-        <video class="video" src="<%= video %>"></video>
+          <video class="video" src="<%= video %>"></video>
         <% end %>
-        <%=  "<div id='noresult'>映像がありませんでした。</div>" if @videos.empty? %>
+        <% if @videos.empty? %>
+          <div id='noresult'>映像がありませんでした。</div>
+        <% end %>
 
     </div>
 </body>


### PR DESCRIPTION
Since the code below directly renders user input, so that it has XSS vulnerability.

in `views/result.erb`

```
<div id="bpm"><%= @bpm %></div>
```

in `main.rb`

```
post '/result' do
  @bpm = params["bpm"]
```

To prevent this, you need to escape html code. There is two option in Sinatra.
1. Use helper method http://www.sinatrarb.com/faq.html#escape_html
2. Add gem to escape html automatically http://www.sinatrarb.com/faq.html#auto_escape_html

Actually, Rails automatically escape inputs but Sinatra doesn't. So I choose option 2, for the usability and future safety.

Please take a look :smile_cat: 
